### PR TITLE
Enable wildcard handling for ansible unarchive tar

### DIFF
--- a/tasks/install-archive.yml
+++ b/tasks/install-archive.yml
@@ -49,7 +49,7 @@
     remote_src: yes
     owner: "{{ exist_instuser }}"
     group: "{{ exist_group }}"
-    extra_opts: [ '--transform=s:^[^/]\+:{{ exist_instname }}:;', '*exist-core*jar' ]
+    extra_opts: [ '--transform=s:^[^/]\+:{{ exist_instname }}:;', '--wildcards', '*exist-core*jar' ]
   when: exist_major_version == 5
   tags:
     - install


### PR DESCRIPTION
Add '--wildcards' option to ansible module unarchive as we are handling
a tar archive and some versions of tar don't handle wildcards without
being explicitly told.