### PR TITLE
use 'exist_java_home' instead of 'ansible_env.JAVA_HOME'

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,9 @@ get set. They are persistent and not re-set in later Ansible runs.
 Exist DB requires Java. Installing Java is outside of scope of this role, we
 assume:
 * Java JDK is installed (JRE might be sufficient in some situations, but you can't build from source then)
-* the `JAVA_HOME` environment variable is correctly set up
+* the fact 'exist_java_home' is set by the calling playbook OR
+  an ansible fact gathering script populating 'ansible_local.java.java_home' was deployed OR
+  the `JAVA_HOME` environment variable is correctly set up
 * Java binaries are in the shell `$PATH`
 
 ## In the Works

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,21 @@
 ---
+- name: Gather facts
+  setup:
+
+- name: Get exist_java_home from ansible facts
+  set_fact:
+    exist_java_home: "{{ ansible_local.java.java_home }}"
+  when: "( ( exist_java_home is not defined ) and ( ( ansible_local.java is defined ) and ( ansible_local.java.java_home is defined ) ) )"
+
+- name: Get exist_java_home from environment
+  set_fact:
+    exist_java_home: "{{ ansible_env.JAVA_HOME }}"
+  when: "( ( exist_java_home is not defined ) and ( ( ansible_env is defined ) and ( ansible_env.JAVA_HOME is defined ) ) )"
+
+- fail:
+    msg: Java not found
+  when: exist_java_home is not defined
+
 - name: Set facts for this exist instance
   set_fact:
     exist_path: "{{ exist_home }}/{{ exist_instname }}"

--- a/templates/eXist-db.init-v4.j2
+++ b/templates/eXist-db.init-v4.j2
@@ -17,16 +17,16 @@
 #-----------------------------------------------------------------------------
 
 status() {
-     {{ ansible_env.JAVA_HOME }}/bin/java -Dwrapper.pidfile={{ exist_path }}/wrapper.eXist-db.pid -Dwrapper.service=true -Dwrapper.visible=false -Djna_tmpdir={{ exist_home }}/tmp -jar {{ exist_path }}/tools/yajsw/wrapper.jar -qx {{ exist_path }}/tools/yajsw/conf/wrapper.conf
+     {{ exist_java_home }}/bin/java -Dwrapper.pidfile={{ exist_path }}/wrapper.eXist-db.pid -Dwrapper.service=true -Dwrapper.visible=false -Djna_tmpdir={{ exist_home }}/tmp -jar {{ exist_path }}/tools/yajsw/wrapper.jar -qx {{ exist_path }}/tools/yajsw/conf/wrapper.conf
 }
 
 stopit() {
     echo "Stopping eXist-db ..."
-    {{ ansible_env.JAVA_HOME }}/bin/java -Dwrapper.pidfile={{ exist_path }}/wrapper.eXist-db.pid -Dwrapper.service=true -Dwrapper.visible=false -Djna_tmpdir={{ exist_home }}/tmp -jar {{ exist_path }}/tools/yajsw/wrapper.jar -px {{ exist_path }}/tools/yajsw/conf/wrapper.conf
+    {{ exist_java_home }}/bin/java -Dwrapper.pidfile={{ exist_path }}/wrapper.eXist-db.pid -Dwrapper.service=true -Dwrapper.visible=false -Djna_tmpdir={{ exist_home }}/tmp -jar {{ exist_path }}/tools/yajsw/wrapper.jar -px {{ exist_path }}/tools/yajsw/conf/wrapper.conf
 }
 startit() {
     echo "Starting eXist-db ..."
-    sudo -u {{ exist_instuser }} {{ ansible_env.JAVA_HOME }}/bin/java -Dwrapper.pidfile={{ exist_path }}/wrapper.eXist-db.pid -Dwrapper.service=true -Dwrapper.visible=false -Djna_tmpdir={{ exist_home }}/tmp -jar {{ exist_path }}/tools/yajsw/wrapper.jar -tx {{ exist_path }}/tools/yajsw/conf/wrapper.conf
+    sudo -u {{ exist_instuser }} {{ exist_java_home }}/bin/java -Dwrapper.pidfile={{ exist_path }}/wrapper.eXist-db.pid -Dwrapper.service=true -Dwrapper.visible=false -Djna_tmpdir={{ exist_home }}/tmp -jar {{ exist_path }}/tools/yajsw/wrapper.jar -tx {{ exist_path }}/tools/yajsw/conf/wrapper.conf
 }
 
 

--- a/templates/eXist-db.systemd-v4.j2
+++ b/templates/eXist-db.systemd-v4.j2
@@ -6,8 +6,8 @@ After=syslog.target
 [Service]
 Type=forking
 User={{exist_instuser}}
-ExecStart={{ ansible_env.JAVA_HOME }}/bin/java -Dwrapper.pidfile={{ exist_path }}/tools/yajsw/work/wrapper.eXist-db.pid -Dwrapper.service=true -Dwrapper.visible=false -Djna_tmpdir={{exist_home}}/tmp -jar {{ exist_path }}/tools/yajsw/wrapper.jar -tx {{ exist_path }}/tools/yajsw/conf/wrapper.conf
-ExecStop={{ ansible_env.JAVA_HOME }}/bin/java -Dwrapper.pidfile={{ exist_path }}/tools/yajsw/work/wrapper.eXist-db.pid -Dwrapper.service=true -Dwrapper.visible=false -Djna_tmpdir={{exist_home}}/tmp -jar {{ exist_path }}/tools/yajsw/wrapper.jar -px {{ exist_path }}/tools/yajsw/conf/wrapper.conf
+ExecStart={{ exist_java_home }}/bin/java -Dwrapper.pidfile={{ exist_path }}/tools/yajsw/work/wrapper.eXist-db.pid -Dwrapper.service=true -Dwrapper.visible=false -Djna_tmpdir={{exist_home}}/tmp -jar {{ exist_path }}/tools/yajsw/wrapper.jar -tx {{ exist_path }}/tools/yajsw/conf/wrapper.conf
+ExecStop={{ exist_java_home }}/bin/java -Dwrapper.pidfile={{ exist_path }}/tools/yajsw/work/wrapper.eXist-db.pid -Dwrapper.service=true -Dwrapper.visible=false -Djna_tmpdir={{exist_home}}/tmp -jar {{ exist_path }}/tools/yajsw/wrapper.jar -px {{ exist_path }}/tools/yajsw/conf/wrapper.conf
 Restart=on-abort
 StandardOutput=null
 

--- a/templates/service.sh.j2
+++ b/templates/service.sh.j2
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 EXIST_DIR={{ exist_path }}
-JAVA_HOME={{ ansible_env.JAVA_HOME }}
+JAVA_HOME={{ exist_java_home }}
 
 # default opts as used in the launcher.sh or startup.sh scripts
 EXIST_DEFAULT_OPTS="\
@@ -29,4 +29,4 @@ EXIST_BOOTER_OPTS="\
   -Dbasedir=${EXIST_DIR} \
   org.codehaus.mojo.appassembler.booter.AppassemblerBooter"
 
-exec {{ ansible_env.JAVA_HOME }}/bin/java ${EXIST_DEFAULT_OPTS} ${EXIST_CUSTOM_OPTS} ${EXIST_BOOTER_OPTS}
+exec {{ exist_java_home }}/bin/java ${EXIST_DEFAULT_OPTS} ${EXIST_CUSTOM_OPTS} ${EXIST_BOOTER_OPTS}

--- a/templates/wrapper.conf.j2
+++ b/templates/wrapper.conf.j2
@@ -7,7 +7,7 @@
 # Java Executable Properties
 #********************************************************************
 # Java Application
-wrapper.java.command={{ ansible_env.JAVA_HOME }}/bin/java
+wrapper.java.command={{ exist_java_home }}/bin/java
 
 # or define conditions for YAJSW searching for a JVM
 # currently only valid for windows


### PR DESCRIPTION
Gather facts.
If 'exist_java_home' is defined use that.
Else if ansible fact gathering script populated
  'ansible_local.java.java_home' use that.
Else if environment variable 'JAVA_HOME' is set use that.
Else fail with 'Java not found'.