### PR TITLE
make confxml template handle boolean variables cleaner

### DIFF
--- a/templates/conf_4.xml.j2
+++ b/templates/conf_4.xml.j2
@@ -373,8 +373,8 @@
                 and if inconsistencies are found in the db, it writes an emergency
                 backup to the same directory.
         -->
-        <recovery enabled="{{exist_confxml_recovery_enabled}}"  group-commit="no"   journal-dir="webapp/WEB-INF/data"
-                  size="100M" sync-on-commit="no"  force-restart="no"  consistency-check="{{exist_confxml_recovery_consistency_check}}"/>
+        <recovery enabled="{% if exist_confxml_recovery_enabled|bool is sameas true %}yes{% else %}no{% endif %}"  group-commit="no"   journal-dir="webapp/WEB-INF/data"
+                  size="100M" sync-on-commit="no"  force-restart="no"  consistency-check="{% if exist_confxml_recovery_consistency_check|bool is sameas true %}yes{% else %}no{% endif %}"/>
 
         <!--
             This is the global configuration for the query watchdog. The 
@@ -592,7 +592,7 @@
             class="org.exist.storage.ConsistencyCheckTask"
             cron-trigger="{{exist_confxml_job_check1_cron_trigger}}">
             <parameter name="output" value="{{exist_confxml_job_check1_output}}"/>
-            <parameter name="backup" value="{{exist_confxml_job_check1_backup}}"/>
+            <parameter name="backup" value="{% if exist_confxml_job_check1_backup|bool is sameas true %}yes{% else %}no{% endif %}"/>
             <parameter name="incremental" value="no"/>
             <parameter name="incremental-check" value="no"/>
             <parameter name="max" value="2"/>
@@ -720,7 +720,7 @@
 
     -->
     <serializer add-exist-id="none" compress-output="no" enable-xinclude="yes"
-                enable-xsl="no" indent="{{exist_confxml_serializer_indent}}" match-tagging-attributes="no" 
+                enable-xsl="no" indent="{% if exist_confxml_serializer_indent|bool is sameas true %}yes{% else %}no{% endif %}" match-tagging-attributes="no"
                 match-tagging-elements="no">
         <!--
             You may add as many custom-filters as you want, they will be executed

--- a/templates/conf_5.xml.j2
+++ b/templates/conf_5.xml.j2
@@ -358,8 +358,8 @@
                 and if inconsistencies are found in the db, it writes an emergency
                 backup to the same directory.
         -->
-        <recovery enabled="{{exist_confxml_recovery_enabled}}" group-commit="no" journal-dir="../data"
-                  size="100M" sync-on-commit="no" force-restart="no" consistency-check="{{exist_confxml_recovery_consistency_check}}"/>
+        <recovery enabled="{% if exist_confxml_recovery_enabled|bool is sameas true %}yes{% else %}no{% endif %}" group-commit="no" journal-dir="../data"
+                  size="100M" sync-on-commit="no" force-restart="no" consistency-check="{% if exist_confxml_recovery_consistency_check|bool is sameas true %}yes{% else %}no{% endif %}"/>
 
         <!--
             This is the global configuration for the query watchdog. The 
@@ -451,7 +451,7 @@
                 This can also be set via the Java System Properties `org.exist.lock-manager.lock-table.trace-stack-depth`,
                     or (legacy) `exist.locktable.trace.stack.depth`.
         -->
-        <lock-table disabled="{{exist_confxml_lock_table_disabled}}" trace-stack-depth="0"/>
+        <lock-table disabled="{% if exist_confxml_lock_table_disabled|bool is sameas true %}true{% else %}false{% endif %}" trace-stack-depth="0"/>
 
 
         <!-- Settings for Document Locking
@@ -663,7 +663,7 @@
             class="org.exist.storage.ConsistencyCheckTask"
             cron-trigger="{{exist_confxml_job_check1_cron_trigger}}">
             <parameter name="output" value="{{exist_confxml_job_check1_output}}"/>
-            <parameter name="backup" value="{{exist_confxml_job_check1_backup}}"/>
+            <parameter name="backup" value="{% if exist_confxml_job_check1_backup|bool is sameas true %}yes{% else %}no{% endif %}"/>
             <parameter name="incremental" value="no"/>
             <parameter name="incremental-check" value="no"/>
             <parameter name="max" value="2"/>
@@ -819,7 +819,7 @@
 
     -->
     <serializer add-exist-id="none" compress-output="no" enable-xinclude="yes"
-                enable-xsl="no" indent="{{exist_confxml_serializer_indent}}" match-tagging-attributes="no"
+                enable-xsl="no" indent="{% if exist_confxml_serializer_indent|bool is sameas true %}yes{% else %}no{% endif %}" match-tagging-attributes="no"
                 match-tagging-elements="no">
         <!--
             You may add as many custom-filters as you want, they will be executed


### PR DESCRIPTION
Some settings in conf.yml must be set to literal 'yes' or 'no' instead
of 'true' or 'false'. But from ansible they could be interpreted as
boolean. This leads to errors as 'wrong' setting strings seem to get
silently ignored by existdb.
Now we cast those variables to boolean, test for true and emit 'yes'
or 'no'.