### PR TITLE
make webxml template handle boolean variables cleaner

### DIFF
--- a/templates/web.xml.j2
+++ b/templates/web.xml.j2
@@ -116,7 +116,7 @@
 		-->
         <init-param>
             <param-name>hidden</param-name>
-            <param-value>{{exist_webxml_initparam_hidden}}</param-value>
+            <param-value>{% if exist_webxml_initparam_hidden|bool is sameas true %}true{% else %}false{% endif %}</param-value>
         </init-param>
 
         <!--


### PR DESCRIPTION
Some settings in web.xml must be set to literal 'true' or 'false'.
But from ansible they could be interpreted as boolean, yealding
e.g. 'True'. This leads to errors as 'wrong' setting strings seem to get
silently ignored by existdb.
Now we cast those variables to boolean, test for true and emit 'true'
or 'false'.