### PR TITLE
Feature/service discovery for backup

### DIFF
--- a/tasks/startup.yml
+++ b/tasks/startup.yml
@@ -1,7 +1,7 @@
 ---
 ## tasks for post installation that need exist running
 
-- name: Ensure exist service is running
+- name: Ensure exist service is (re-)started
   service:
     name: "{{ exist_instname }}"
     enabled: yes

--- a/tasks/stop-and-backup.yml
+++ b/tasks/stop-and-backup.yml
@@ -1,8 +1,12 @@
 ---
+- name: Collect facts on existing services
+  service_facts:
+
 - name: Ensure exist instance is stopped
   service:
     name: "{{ exist_instname }}"
     state: stopped
+  when: exist_instname in services
   tags:
     - backup
 


### PR DESCRIPTION
backup task fails if to-be-backed-up existdb cannot be stopped because it is already stopped.
now we only try to stop running instances.