### PR TITLE
Feature/upload xmlrpc python3

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -185,7 +185,6 @@ exist_redhat_extra_packages:
   # for Ansible synchronize
   - rsync
   # for upload-xmlrpc script
-  - perl-RPC-XML
   - perl-LWP-Protocol-https
 
 # for Debian 8

--- a/files/upload-xmlrpc.py
+++ b/files/upload-xmlrpc.py
@@ -40,11 +40,15 @@ xmlrpcSchema = "https"
 if args.T:
     xmlrpcSchema = "http"
 xmlrpcOwner = args.owner
+xmlrpcGroup = args.group
 xmlrpcMode = args.mode
+xmlrpcParse = 1
 xmlrpcMime = args.mime
 if args.Q:
+    xmlrpcParse = 0
     xmlrpcMime = "application/xquery"
 if args.L:
+    xmlrpcParse = 0
     xmlrpcMime = "text/html"
 if args.B:
     xmlrpcMime = "application/octet-stream"
@@ -90,10 +94,10 @@ with ServerProxy('{xmlrpcSchema}://{xmlrpcUser}:{xmlrpcPass}@{xmlrpcHost}:{xmlrp
             upres = proxy.upload(data, len(data))
             print(upres)
             #pares = proxy.parseLocalExt(str(upres), fname, replace=1, mime='application/xml', parse=1)
-            pares = proxy.parseLocalExt(str(upres), fname, 1, xmlrpcMime, 1)
+            pares = proxy.parseLocalExt(str(upres), fname, 1, xmlrpcMime, xmlrpcParse)
             print(pares)
             #spres = proxy.setPermissions(fname, owner='admin', group='SYSTEM', mode='rw-r--r--')
-            spres = proxy.setPermissions(fname, 'admin', 'SYSTEM', 'rw-r--r--')
+            spres = proxy.setPermissions(fname, xmlrpcOwner, xmlrpcGroup, xmlrpcMode)
             print(spres)
         except Error as v:
             print("ERROR", v)

--- a/files/upload-xmlrpc.py
+++ b/files/upload-xmlrpc.py
@@ -1,0 +1,106 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+
+import argparse
+import base64
+import os
+import socket
+import sys
+
+from xmlrpc.client import ServerProxy, Error
+
+parser = argparse.ArgumentParser()
+#parser.add_argument("echo", help="echo the string you use here", type=str)
+#parser.add_argument("num", type=int, help="double the number you use here")
+parser.add_argument("-d", "--debug",  action="store_true", help="enable debug output")
+parser.add_argument("-t", "--timeout", type=int, default=180, help="connection timeout")
+parser.add_argument("-u", "--user", default="admin", help="username to login to eXist XML RPC (default: admin)")
+parser.add_argument("-p", "--pass", default="", help="password to login to eXist XML RPC (default: \"\")")
+parser.add_argument("-H", "--host", default="localhost", help="URL hostname (default: localhost)")
+parser.add_argument("-P", "--port", type=int, default=8080, help="URL port (default: 8443)")
+parser.add_argument("-T", action="store_true", help="disable TLS connection (default: enabled)")
+parser.add_argument("-o", "--owner", default="admin", help="set owner of uploaded file (default: admin)")
+parser.add_argument("-g", "--group", default="SYSTEM", help="set group of uploaded file (default: SYSTEM)")
+parser.add_argument("-m", "--mode", default="rw-r--r--", help="set mode  of uploaded file (default: rw-r--r--) - NOT 0644 format!")
+parser.add_argument("-M", "--mime", default="application/xml", help="set MIME type of uploaded file (default: application/xml)")
+parser.add_argument("-Q", action="store_true", help="uploaded file is XQuery, shortcut for \"-M application/xquery\"")
+parser.add_argument("-L", action="store_true", help="uploaded file is HTML, shortcut for \"-M text/html\"")
+parser.add_argument("-B", action="store_true", help="uploaded file is binary [NOT IMPLEMENTED YET]")
+parser.add_argument("file-name", default="", nargs="?", help="name of file to upload")
+args = parser.parse_args()
+#print(args)
+
+xmlrpcDebug = args.debug
+xmlrpcTimeout = args.timeout
+xmlrpcUser = args.user
+xmlrpcPass = vars(args)['pass']
+xmlrpcHost = args.host
+xmlrpcPort = args.port
+xmlrpcSchema = "https"
+if args.T:
+    xmlrpcSchema = "http"
+xmlrpcOwner = args.owner
+xmlrpcMode = args.mode
+xmlrpcMime = args.mime
+if args.Q:
+    xmlrpcMime = "application/xquery"
+if args.L:
+    xmlrpcMime = "text/html"
+if args.B:
+    xmlrpcMime = "application/octet-stream"
+
+scriptName = os.path.basename(sys.argv[0])
+#print(scriptName)
+fname = sys.argv[-1]
+#print(fname)
+
+data = sys.stdin.read().encode()
+#data = "\n".join(sys.stdin.readlines())
+#print(data)
+#sys.exit()
+
+
+
+socket.setdefaulttimeout(xmlrpcTimeout)
+
+with ServerProxy('{xmlrpcSchema}://{xmlrpcUser}:{xmlrpcPass}@{xmlrpcHost}:{xmlrpcPort}/exist/xmlrpc'.format(**locals())) as proxy:
+    #print(proxy)
+    if (scriptName == 'execute-xmlrpc.py'):
+        print(scriptName)
+        #xquery = '(<test1/>,<test2/>)'
+        xquery = data
+        limitResultNumberTo = 100 # 0 to disable
+        startWithResultNumber = 1
+        params = {}
+        try:
+            print(proxy.query(xquery, limitResultNumberTo, startWithResultNumber, params))
+        except Error as v:
+            print("ERROR", v)
+            sys.exit(-1)
+        pass
+        sys.exit()
+    elif (scriptName == 'upload-xmlrpc.py'):
+        #print(scriptName)
+        #b64 = base64.b64encode(data.encode('utf-8'))
+        upres = -1
+        pares = -1
+        spres = -1
+        try:
+            #upres = proxy.upload(data, len(base64(data)))
+            upres = proxy.upload(data, len(data))
+            print(upres)
+            #pares = proxy.parseLocalExt(str(upres), fname, replace=1, mime='application/xml', parse=1)
+            pares = proxy.parseLocalExt(str(upres), fname, 1, xmlrpcMime, 1)
+            print(pares)
+            #spres = proxy.setPermissions(fname, owner='admin', group='SYSTEM', mode='rw-r--r--')
+            spres = proxy.setPermissions(fname, 'admin', 'SYSTEM', 'rw-r--r--')
+            print(spres)
+        except Error as v:
+            print("ERROR", v)
+            sys.exit(-1)
+        pass
+        sys.exit()
+
+if __name__=='__main__':
+    #print("hello, world!")
+    pass

--- a/tasks/postinstall.yml
+++ b/tasks/postinstall.yml
@@ -132,6 +132,7 @@
     mode: 0751
   with_items:
     - upload-xmlrpc.pl
+    - upload-xmlrpc.py
   tags:
     - config
 
@@ -139,6 +140,17 @@
   file:
     src: "{{ exist_path }}/contrib/upload-xmlrpc.pl"
     dest: "{{ exist_path }}/contrib/execute-xmlrpc.pl"
+    state: hard
+    force: yes
+    owner: "{{ exist_instuser }}"
+    group: "{{ exist_group }}"
+  tags:
+    - config
+
+- name: Hardlink upload-xmlrpc.py to execute-xmlrpc.py
+  file:
+    src: "{{ exist_path }}/contrib/upload-xmlrpc.py"
+    dest: "{{ exist_path }}/contrib/execute-xmlrpc.py"
     state: hard
     force: yes
     owner: "{{ exist_instuser }}"

--- a/tasks/startup.yml
+++ b/tasks/startup.yml
@@ -61,7 +61,7 @@
 
 - name: Set admin password (exec set-adminpass.xql)
   #shell: 'bin/client.sh -u admin -P "" -F set-adminpass.xql && touch {{ exist_datadir }}/.password-set'
-  shell: 'contrib/execute-xmlrpc.pl -u admin -p "" -P {{ exist_http_port }} -T < "{{ exist_path }}/set-adminpass.xql" && touch "{{ exist_datadir }}/.password-set"'
+  shell: 'contrib/execute-xmlrpc.py -u admin -p "" -P {{ exist_http_port }} -T < "{{ exist_path }}/set-adminpass.xql" && touch "{{ exist_datadir }}/.password-set"'
   args:
     chdir: "{{ exist_path }}"
   when: not password_set_file.stat.exists
@@ -84,7 +84,7 @@
 
 - name: Install custom xar files (exec install-xars.xql)
   #shell: 'bin/client.sh -u admin -P "{{ exist_adminpass[inventory_hostname][exist_instname] }}" -F contrib/install-xars.xql -ouri=xmldb:exist://localhost:{{ exist_http_port }}/exist/xmlrpc'
-  shell: 'contrib/execute-xmlrpc.pl -u admin -p "{{ exist_adminpass[inventory_hostname][exist_instname] }}" -P {{ exist_http_port }} -t 4800 -T < contrib/install-xars.xql'
+  shell: 'contrib/execute-xmlrpc.py -u admin -p "{{ exist_adminpass[inventory_hostname][exist_instname] }}" -P {{ exist_http_port }} -t 4800 -T < contrib/install-xars.xql'
   args:
     chdir: "{{ exist_path }}"
   when:
@@ -107,7 +107,7 @@
 
 - name: Run post-install/hardening (exec users-and-groups.xql)
   #shell: 'bin/client.sh -u admin -P "{{ exist_adminpass[inventory_hostname][exist_instname] }}" -p {{ exist_http_port }} -F users-and-groups.xql'
-  shell: 'contrib/execute-xmlrpc.pl -u admin -p "{{ exist_adminpass[inventory_hostname][exist_instname] }}" -P {{ exist_http_port }} -T < "{{ exist_path }}/users-and-groups.xql"'
+  shell: 'contrib/execute-xmlrpc.py -u admin -p "{{ exist_adminpass[inventory_hostname][exist_instname] }}" -P {{ exist_http_port }} -T < "{{ exist_path }}/users-and-groups.xql"'
   args:
     chdir: "{{ exist_path }}"
   tags:

--- a/templates/exist-serverside-backup.sh.j2
+++ b/templates/exist-serverside-backup.sh.j2
@@ -15,7 +15,7 @@ TIMEOUT=14400                   # 4 hours
 EXIST_BASEDIR={{ exist_home }}
 
 
-${EXIST_BASEDIR}/${INSTNAME}/contrib/execute-xmlrpc.pl \
+${EXIST_BASEDIR}/${INSTNAME}/contrib/execute-xmlrpc.py \
   -u ${ADMIN_USER} -p "${ADMIN_PASS}" -P {{ exist_http_port }} -T \
   -t ${TIMEOUT} <<XQUERY
 xquery version "3.1";

--- a/templates/exist-serverside-backup.sh.j2
+++ b/templates/exist-serverside-backup.sh.j2
@@ -20,12 +20,12 @@ ${EXIST_BASEDIR}/${INSTNAME}/contrib/execute-xmlrpc.py \
   -t ${TIMEOUT} <<XQUERY
 xquery version "3.1";
 
-let $params :=
+let \$params :=
  <parameters>
    <param name="output" value="${BACKUP_DEST}"/>
     <param name="backup" value="yes"/>
     <param name="incremental" value="${INCREMENTAL}"/>
  </parameters>
  return
-    system:trigger-system-task("org.exist.storage.ConsistencyCheckTask", $params)
+    system:trigger-system-task("org.exist.storage.ConsistencyCheckTask", \$params)
 XQUERY


### PR DESCRIPTION
remove dependency on perl-RPC-XML.
on centos/8 some perl modules were removed from repo core and epel.
as we are using ansible we already depend on python.