### PR TITLE
add option 'remote_src' to items of 'xar_install'

### DIFF
--- a/tasks/custom-xar-install.yml
+++ b/tasks/custom-xar-install.yml
@@ -33,6 +33,7 @@
     dest: "{{ exist_path }}/xars/{{ item.name }}"
     owner: "{{ exist_instuser }}"
     group: "{{ exist_group }}"
+    remote_src: "{{ item.remote_src | default(xar_default.remote_src|default('no')) }}"
   #with_items: "{{ ansible_local[exist_instname]['exist_custom']['xar-install'] }}"
   with_items: "{{ xar_install }}"
   when:


### PR DESCRIPTION
If 'remote_src' is true for an item, set ansible module 'copy'
'remote_src: true' for this item. Defaults to 'false'.