### PR TITLE
Add additional memory settings for Java

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Memory settings for this eXist-db instance. They map to the Java flags `-Xms`,
 
     exist_mem_gc: 'g1'
     exist_mem_g1gc_pausegoal: 200
+    exist_mem_numa_enable: no
     exist_mem_gcdebug_enable: no
     exist_mem_nmt_enable: no
     exist_mem_strdedup_enable: yes
@@ -131,6 +132,7 @@ Memory settings for this eXist-db instance. They map to the Java flags `-Xms`,
 Special memory settings suited for high-load installations:
 * `exist_mem_gc` is the garbage collector to use, recognised values are: `serial`, `parallel`, `cms`, `g1`, `z`, and `shenandoah`.
 * `exist_mem_g1gc_pausegoal` is the value of Java option `-XX:MaxGCPauseMillis`; only relevant if `exist_mem_gc == 'g1'`.
+* `exist_mem_numa_enable` activates/deactivates the Java option `-XX:+UseNUMA`; This should only be used with Java 11+ due to the issue: https://bugs.openjdk.java.net/browse/JDK-8189922
 * `exist_mem_gcdebug_enable` enables GC logging for memory usage analysis
 * `exist_mem_nmt_enable` enable Java Native Memory Tracking. **NOTE** ignored for exist 4.x because of conflicts with the YAJSW wrapper
 * `exist_mem_strdedup_enable` enables Java String Deduplication

--- a/README.md
+++ b/README.md
@@ -127,7 +127,12 @@ Memory settings for this eXist-db instance. They map to the Java flags `-Xms`,
     exist_mem_strdedup_enable: no
     exist_mem_niocachetune_enable: no
 
-Special memory settings suited for high-load installations: `exist_mem_g1gc_pausegoal` is the value of Java option `-XX:MaxGCPauseMillis`; `exist_mem_gcdebug_enable` enables GC logging for memory usage analysis; `exist_mem_nmt_enable` enable Java Native Memory Tracking. **NOTE** ignored for exist 4.x because of conflicts with the YAJSW wrapper; `exist_mem_strdedup_enable` enables Java String Deduplication; `exist_mem_niocachetune_enable` works around a bug in java.nio that may lead to excessive memory usage in Java version < 11. This issue appears only in high load environments
+Special memory settings suited for high-load installations:
+* `exist_mem_g1gc_pausegoal` is the value of Java option `-XX:MaxGCPauseMillis`
+* `exist_mem_gcdebug_enable` enables GC logging for memory usage analysis
+* `exist_mem_nmt_enable` enable Java Native Memory Tracking. **NOTE** ignored for exist 4.x because of conflicts with the YAJSW wrapper
+* `exist_mem_strdedup_enable` enables Java String Deduplication
+* `exist_mem_niocachetune_enable` works around a bug in java.nio that may lead to excessive memory usage in Java version < 11. This issue appears only in high load environments
 
     exist_major_version: 4
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Memory settings for this eXist-db instance. They map to the Java flags `-Xms`,
     exist_mem_g1gc_pausegoal: 200
     exist_mem_gcdebug_enable: no
     exist_mem_nmt_enable: no
-    exist_mem_strdedup_enable: no
+    exist_mem_strdedup_enable: yes
     exist_mem_niocachetune_enable: no
 
 Special memory settings suited for high-load installations:

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ details.
 Memory settings for this eXist-db instance. They map to the Java flags `-Xms`,
 `-Xmx`, `-XX:MaxMetaspaceSize` and `-XX:MaxDirectMemorySize`.
 
+    exist_mem_gc: 'g1'
     exist_mem_g1gc_pausegoal: 200
     exist_mem_gcdebug_enable: no
     exist_mem_nmt_enable: no
@@ -128,7 +129,8 @@ Memory settings for this eXist-db instance. They map to the Java flags `-Xms`,
     exist_mem_niocachetune_enable: no
 
 Special memory settings suited for high-load installations:
-* `exist_mem_g1gc_pausegoal` is the value of Java option `-XX:MaxGCPauseMillis`
+* `exist_mem_gc` is the garbage collector to use, recognised values are: `serial`, `parallel`, `cms`, `g1`, `z`, and `shenandoah`.
+* `exist_mem_g1gc_pausegoal` is the value of Java option `-XX:MaxGCPauseMillis`; only relevant if `exist_mem_gc == 'g1'`.
 * `exist_mem_gcdebug_enable` enables GC logging for memory usage analysis
 * `exist_mem_nmt_enable` enable Java Native Memory Tracking. **NOTE** ignored for exist 4.x because of conflicts with the YAJSW wrapper
 * `exist_mem_strdedup_enable` enables Java String Deduplication

--- a/README.md
+++ b/README.md
@@ -134,6 +134,13 @@ Special memory settings suited for high-load installations:
 * `exist_mem_strdedup_enable` enables Java String Deduplication
 * `exist_mem_niocachetune_enable` works around a bug in java.nio that may lead to excessive memory usage in Java version < 11. This issue appears only in high load environments
 
+Out of Memory error settings for this eXist-db instance. These only take effect if the JVM runs out of memory for eXist-db to operate. As it is almost impossible to recover from a Java OutOfMemoryError, it is recommened to at least enable `exist_mem_exitoom_enable` as this will help possible further corruption to the eXist-db database itself.
+
+    exist_mem_exitoom_enable: yes
+    exist_mem_dumpoom_enable: no
+
+The `exist_mem_dumpoom_enable` setting will cause the JVM to write a Heap Dump file to `$EXIST_HOME/dump` if it runs out of memory. This can be useful for debugging possible Memory Leaks in eXist-db, or analyzing where eXist-db applications are consuming excessive memory.
+
     exist_major_version: 4
 
 You need to explicitly specify whether you are going to install an eXist-db 4.x

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -46,6 +46,10 @@ exist_mem_nmt_enable: no
 exist_mem_strdedup_enable: no
 exist_mem_niocachetune_enable: no
 
+# OOM memory settings
+exist_mem_exitoom_enable: yes
+exist_mem_dumpoom_enable: no
+
 # because eXist-db 5.0 introduces many changes in its filesystem layout that
 # affect Ansible operation, we use this variable as an indicator for Ansible
 # processing. Expected values:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -42,6 +42,7 @@ exist_mem_max_direct: 1024
 # special memory/GC settings
 exist_mem_gc: 'g1'
 exist_mem_g1gc_pausegoal: 200
+exist_mem_numa_enable: no
 exist_mem_gcdebug_enable: no
 exist_mem_nmt_enable: no
 exist_mem_strdedup_enable: yes

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -43,7 +43,7 @@ exist_mem_max_direct: 1024
 exist_mem_g1gc_pausegoal: 200
 exist_mem_gcdebug_enable: no
 exist_mem_nmt_enable: no
-exist_mem_strdedup_enable: no
+exist_mem_strdedup_enable: yes
 exist_mem_niocachetune_enable: no
 
 # OOM memory settings

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -40,6 +40,7 @@ exist_mem_max_meta: 1024
 exist_mem_max_direct: 1024
 
 # special memory/GC settings
+exist_mem_gc: 'g1'
 exist_mem_g1gc_pausegoal: 200
 exist_mem_gcdebug_enable: no
 exist_mem_nmt_enable: no

--- a/templates/exist.java.options.j2
+++ b/templates/exist.java.options.j2
@@ -58,6 +58,11 @@
 -XX:+UseShenandoahGC
 {% endif %}
 
+# NUMA
+{% if exist_mem_numa_enable|bool is sameas true %}
+-XX:+UseNUMA
+{% endif %}
+
 # GC logging/debugging
 {% if exist_mem_gcdebug_enable|bool is sameas true %}
 -XX:+PrintGCDetails

--- a/templates/exist.java.options.j2
+++ b/templates/exist.java.options.j2
@@ -92,6 +92,15 @@
 #-Djdk.nio.maxCachedBufferSize=262144
 {% endif %}
 
+{% if exist_mem_dumpoom_enable|bool is sameas true %}
+-XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath={{ exist_home }}/dump
+{% endif %}
+
+{% if exist_mem_exitoom_enable|bool is sameas true %}
+-XX:+ExitOnOutOfMemoryError
+{% endif %}
+
+
 # tmp dir
 -Djava.io.tmpdir={{ exist_home }}/tmp
 

--- a/templates/exist.java.options.j2
+++ b/templates/exist.java.options.j2
@@ -37,9 +37,27 @@
 -XX:MaxMetaspaceSize={{ exist_mem_max_meta }}m
 -XX:MaxDirectMemorySize={{ exist_mem_max_direct }}m
 
-# GC (default G1 GC)
+# GC
+{% if exist_mem_gc == 'serial' %}
+-XX:+UseSerialGC
+{% endif %}
+{% if exist_mem_gc == 'parallel' %}
+-XX:+UseParallelGC
+{% endif %}
+{% if exist_mem_gc == 'cms' %}
+-XX:+UseConcMarkSweepGC
+{% endif %}
+{% if exist_mem_gc == 'g1' %}
 -XX:+UseG1GC
 -XX:MaxGCPauseMillis={{ exist_mem_g1gc_pausegoal }}
+{% endif %}
+{% if exist_mem_gc == 'z' %}
+-XX:+UseZGC
+{% endif %}
+{% if exist_mem_gc == 'shenandoah' %}
+-XX:+UseShenandoahGC
+{% endif %}
+
 # GC logging/debugging
 {% if exist_mem_gcdebug_enable|bool is sameas true %}
 -XX:+PrintGCDetails


### PR DESCRIPTION
* Ability to control the action to take on `OutOfMemoryError`, i.e. `-XX:+HeapDumpOnOutOfMemoryError`, `-XX:HeapDumpPath`, and `-XX:+ExitOnOutOfMemoryError`.
* Ability to control the NUMA awareness, i.e. `-XX:+UseNUMA`
* Allow the Java Garbage Collection implementation to be set. Defaults to G1GC