### PR TITLE
fix: update exist.fact

### DIFF
--- a/templates/exist.fact.j2
+++ b/templates/exist.fact.j2
@@ -41,7 +41,7 @@ if [ -f $ex_path/etc/conf.xml ]; then
     ex_version=`grep product-version $ex_path/etc/system.properties | sed -e 's/product-version=//;'`
     ex_built=`grep product-build $ex_path/etc/system.properties | sed -e 's/product-build=//;'`
     ex_branch=`grep git-branch $ex_path/etc/system.properties | sed -e 's/git-branch=//;'`
-    ex_revision=`grep git-commit $ex_path/etc/system.properties | sed -e 's/git-commit=//;'`
+    ex_revision=`grep git-commit= $ex_path/etc/system.properties | sed -e 's/git-commit=//;'`
     if [ -f $ex_path/data/jmxservlet.token ]; then
 	ex_jmxtoken=`grep '^token=' $ex_path/data/jmxservlet.token | sed -e 's/token=//;'`
     fi


### PR DESCRIPTION
on existdb 6.2.0 there are two lines in `$ex_path/etc/system.properties` matching the old grep pattern.
this results in a malformed JSON output and by that breaks later playbook runs.
the two fields matching are `git-commit=` and `git-commit-timestamp=`.
extending the grep pattern by `=` makes it unambiguous while retaining compatibility with older verisons.